### PR TITLE
Fix file open messages to be more informative

### DIFF
--- a/src/scaff_BC-reads-1.c
+++ b/src/scaff_BC-reads-1.c
@@ -151,17 +151,17 @@ int main(int argc, char **argv)
     nseq=0;
     if((namef = fopen(argv[args],"r")) == NULL)
     {
-      printf("ERROR main:: alignment file 2 \n");
+      perror("ERROR main:: input read_1 file");
       exit(1);
     }
     if((namef2 = fopen(argv[args+1],"w")) == NULL)
     {
-      printf("ERROR main:: alignment file 2 \n");
+      perror("ERROR main:: output read_1 file");
       exit(1);
     }
     if((namef3 = fopen(argv[args+2],"w")) == NULL)
     {
-      printf("ERROR main:: alignment file 2 \n");
+      perror("ERROR main:: output name_1 file");
       exit(1);
     }
 

--- a/src/scaff_BC-reads-2.c
+++ b/src/scaff_BC-reads-2.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
     nseq=0;
     if((namef = fopen(argv[args],"r")) == NULL)
     {
-      printf("ERROR main:: args \n");
+      perror("ERROR main:: input name_1 file");
       exit(1);
     }
     while(!feof(namef))
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
 
     if((namef = fopen(argv[args],"r")) == NULL)
     {
-      printf("ERROR main:: args \n");
+      perror("ERROR main:: input name_2 file");
       exit(1);
     }
 /*  read the alignment files         */
@@ -188,12 +188,12 @@ int main(int argc, char **argv)
     nseq=0;
     if((namef = fopen(argv[args+1],"r")) == NULL)
     {
-      printf("ERROR main:: alignment file 2 \n");
+      perror("ERROR main:: input read_2 file");
       exit(1);
     }
     if((namef2 = fopen(argv[args+2],"w")) == NULL)
     {
-      printf("ERROR main:: alignment file 2 \n");
+      perror("ERROR main:: out read_2 file");
       exit(1);
     }
 

--- a/src/scaff_BC-reads-2.c
+++ b/src/scaff_BC-reads-2.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
    
     if((read_index = (int *)calloc(nseq,sizeof(int))) == NULL)
     {
-      printf("fmate: calloc - ctg_left\n");
+      perror("fmate: calloc - ctg_left");
       exit(1);
     }
     R_Name = cmatrix(0,nseq+10,0,Max_N_NameBase); 
@@ -938,7 +938,7 @@ int     **imatrix(long nrl,long nrh,long ncl,long nch)
         /* allocate pointers to rows        */
         if((m=(int **)calloc(nrow,sizeof(int*)))==NULL)
         {
-           printf("error imatrix: calloc error No. 1 \n");
+           perror("error imatrix: calloc error No. 1");
            return(NULL);
         }
         m+=0;
@@ -947,7 +947,7 @@ int     **imatrix(long nrl,long nrh,long ncl,long nch)
         /* allocate rows and set pointers to them        */
         if((m[nrl]=(int *)calloc(nrow*ncol,sizeof(int)))==NULL)
         {
-           printf("error imatrix: calloc error No. 2 \n");
+           perror("error imatrix: calloc error No. 2");
            return(NULL);
         }
         m[nrl]+=0;
@@ -968,7 +968,7 @@ char    **cmatrix(long nrl,long nrh,long ncl,long nch)
         /* allocate pointers to rows        */
         if((cm=(char **)calloc(nrow,sizeof(char*)))==NULL)
         {
-           printf("error cmatrix: calloc error No. 1 \n");
+           perror("error cmatrix: calloc error No. 1");
            return(NULL);
         }
         cm+=0;
@@ -977,7 +977,7 @@ char    **cmatrix(long nrl,long nrh,long ncl,long nch)
         /* allocate rows and set pointers to them        */
         if((cm[nrl]=(char *)calloc(nrow*ncol,sizeof(char)))==NULL)
         {
-           printf("error cmatrix: calloc error No. 2 \n");
+           perror("error cmatrix: calloc error No. 2");
            return(NULL);
         }
         cm[nrl]+=0;

--- a/src/scaff_BC-reads-2.c
+++ b/src/scaff_BC-reads-2.c
@@ -169,7 +169,10 @@ int main(int argc, char **argv)
       perror("fmate: calloc - ctg_left");
       exit(1);
     }
-    R_Name = cmatrix(0,nseq+10,0,Max_N_NameBase); 
+    if((R_Name = cmatrix(0,nseq+10,0,Max_N_NameBase)) == NULL)
+    {
+      exit(1);
+    }
 
     if((namef = fopen(argv[args],"r")) == NULL)
     {


### PR DESCRIPTION
I've switched some of the error messages for opening files over to perror, so that the message is a little more informative.