### PR TITLE
fix pigz-2.6 url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## minor edit on the forked repo
+#tracking 
+
 # Scaff10X v5.0
 Pipeline for scaffolding and breaking a genome assembly using 10x genomics linked-reads.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+## minor edit on the forked repo
 # Scaff10X v5.0
 Pipeline for scaffolding and breaking a genome assembly using 10x genomics linked-reads.
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#new comment on install.sh
 
 projdir=`pwd`
 

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ if [[ ! -s $bindir/pigz ]]; then
 
     if [[ ! -d $projdir/src/pigz ]]; then
 	cd $projdir/src/
-        wget -r -np -nd https://zlib.net/pigz/pigz-2.6.tar.gz &> $projdir/src/log/pigz_wget.log
+        wget -r -np -nd https://zlib.net/pigz/fossils/pigz-2.6.tar.gz &> $projdir/src/log/pigz_wget.log
         tar -xvzf pigz-2.6.tar.gz &> $projdir/src/log/pigz_untar.log
         rm -f pigz-2.6.tar.gz
     fi


### PR DESCRIPTION
Installation via install.sh is failing without a good record and it is related to incorrect pigz url (https://zlib.net/pigz/pigz-2.6.tar.gz) on `install.sh` line 83/ Replace it with `https://zlib.net/pigz/fossils/pigz-2.6.tar.gz` to fix the issue. 